### PR TITLE
Switch to CMake and add a desktop file and appdata for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/.DS_Store
 .qmake.stash
 liri-calculator.app
 .DS_Store
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+project(me.liriproject.Calculator)
+
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
+# Find includes in corresponding build directories
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Instruct CMake to run moc and rrc automatically when needed
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+# Extra CMake files
+find_package(ECM 0.0.11 REQUIRED NO_MODULE)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+
+include(KDEInstallDirs)
+include(KDECMakeSettings)
+include(KDECompilerSettings)
+include(FeatureSummary)
+
+# Build flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Werror -Wall -Wextra -Wno-unused-parameter -pedantic -std=c++11")
+
+# Disable debug output for release builds
+if(CMAKE_BUILD_TYPE MATCHES "^[Rr]elease$")
+    add_definitions(-DQT_NO_DEBUG_OUTPUT)
+endif()
+
+# Minimum version requirements
+set(QT_MIN_VERSION "5.4.0")
+
+# Find Qt5
+find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
+             Core
+             Qml
+             Quick)
+
+# Install the desktop and appdata files
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/${PROJECT_NAME}.desktop
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/${PROJECT_NAME}.appdata.xml
+        DESTINATION ${CMAKE_INSTALL_METAINFODIR})
+
+add_subdirectory(src)
+
+# Display feature summary
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/data/me.liriproject.Calculator.appdata.xml
+++ b/data/me.liriproject.Calculator.appdata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Michael Spencer <sonrisesoftware@gmail.com> -->
+<component type="desktop">
+  <id>me.liriproject.Calculator.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0+</project_license>
+  <name>Liri Calculator</name>
+  <summary>Perform arithmetic, scientific or financial calculations</summary>
+  <description>
+    <p>
+      <!-- TODO: Write a better description that isn't a copy of the summary -->
+      Perform arithmetic, scientific or financial calculations.
+    </p>
+  </description>
+  <screenshots>
+    <!-- TODO: Add screenshots -->
+  </screenshots>
+  <!--
+   Validate with `appstream-util validate *.appdata.xml`
+  -->
+  <releases>
+    <!-- TODO: Add a release here -->
+  </releases>
+  <kudos>
+    <!-- TODO: Figure out kudos for Papyros -->
+  </kudos>
+  <url type="homepage">http://liriproject.me</url>
+  <update_contact>pierrejacquier39@gmail.com</update_contact>
+</component>

--- a/data/me.liriproject.Calculator.desktop
+++ b/data/me.liriproject.Calculator.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Liri Calculator
+Comment=Perform arithmetic, scientific or financial calculations
+Keywords=internet;browser;explore;web;
+GenericName=Calculator
+Exec=liri-calculator
+Icon=accessories-calculator
+Terminal=false
+StartupNotify=true
+Type=Application
+Categories=QT;QML;Utility;Calculator;Papyros

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB_RECURSE SOURCES *.cpp *.h liri-calculator.qrc)
+
+add_executable(liri-calculator ${SOURCES})
+target_link_libraries(liri-calculator
+                      Qt5::Core
+                      Qt5::Qml
+                      Qt5::Quick)
+
+install(TARGETS liri-calculator
+        DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,43 +1,42 @@
 /*
-* Liri Calculator - A calculator application for Papyros
-* Copyright (C) 2015 Pierre Jacquier
-* http://pierre-jacquier.com
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Liri Calculator - A calculator application for Papyros
+ * Copyright (C) 2015 Pierre Jacquier (ttp://pierre-jacquier.com)
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
-#ifndef QT_NO_WIDGETS
-#include <QtWidgets/QApplication>
-typedef QApplication Application;
-#else
 #include <QtGui/QGuiApplication>
-typedef QGuiApplication Application;
-#endif
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>
 
-
 int main(int argc, char **argv)
 {
-        Application app(argc, argv);
+        QGuiApplication app(argc, argv);
 
-        app.setOrganizationName("Pierre Jacquier");
-        app.setOrganizationDomain("github.com/pierremtb");
-        app.setApplicationName("liri-calculator");
-        QQmlApplicationEngine appEngine;
-        appEngine.load(QUrl("qrc:/qml/main.qml"));
-        QMetaObject::invokeMethod(appEngine.rootObjects().first(), "load");
+        app.setOrganizationName("Liri Project");
+        app.setOrganizationDomain("liriproject.me");
+        app.setApplicationName("Liri Calculator");
+
+        #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+            app.setDesktopFileName("me.liriproject.Calculator.desktop");
+        #endif
+
+        // Set the X11 WML_CLASS so X11 desktops can find the desktop file
+        qputenv("RESOURCE_NAME", "me.liriproject.Calculator");
+
+        QQmlApplicationEngine engine(QUrl("qrc:/qml/main.qml"));
 
         return app.exec();
 }


### PR DESCRIPTION
CMake lets us do things like automatically installing to the right place, as well as giving us additional configuration and features. The desktop file and appdata will be used in the application menu and software center (including Papyros App Center), as well as the xdg-app package.

Speaking of which, I'll add the configuration necessary to build an xdg-app bundle based off of the Papyros runtime as soon as that's ready. Liri Calculator will be a great testcase for xdg-app as it has no additional dependencies unlike many of the other Papyros and Liri apps.
